### PR TITLE
Skip syncing s3 directories which are created from AWS UI

### DIFF
--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -96,11 +96,13 @@ func (st *S3Storage) List(output chan<- *storage.Object) error {
 		for _, o := range p.Contents {
 			key, _ := url.QueryUnescape(aws.StringValue(o.Key))
 			key = strings.Replace(key, st.prefix, "", 1)
-			output <- &storage.Object{
-				Key:          &key,
-				ETag:         storage.StrongEtag(o.ETag),
-				Mtime:        o.LastModified,
-				StorageClass: o.StorageClass,
+			if string(key[len(key)-1]) != "/" {
+				output <- &storage.Object{
+					Key:          &key,
+					ETag:         storage.StrongEtag(o.ETag),
+					Mtime:        o.LastModified,
+					StorageClass: o.StorageClass,
+				}
 			}
 		}
 		st.listMarker = p.Marker


### PR DESCRIPTION
When we upload an object (i.e. hello/world.txt) to S3 using aws cli
ListObjects command will give you just one object. On the other hand,
if we create a new directory (i.e. hello) from aws UI and then upload
a file world.txt, ListObjetcs will return you two objects i.e.

- hello/ (0B)
- hello/world.txt

This library does not handle this case instead it considers hello/ as
a file and tries to open it and eventually sync operation fails.