### PR TITLE
Implement streaming S3 facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Examples:
 ```s3sync --tk KEY2 --ts SECRET2 --sk KEY1 --ss SECRET1 --se "http://127.0.0.1:7484" --te "http://127.0.0.1:7484" -w 128 s3://shared s3://shared_new```
 * Sync one Amazon bucket directory to another Amazon bucket:  
 ```s3sync --tk KEY2 --ts SECRET2 --sk KEY1 --ss SECRET1 -w 128 s3://shared/test/ s3://shared_new```
+* Use streaming S3 transfers (reduces memory, might be slower for small files):
+```s3sync --sk KEY --ss SECRET --tk KEY --ts SECRET -w 128 s3s://shared/test/ s3s://shared_new```
 
 SOURCE and TARGET should be a directory. Syncing of single file are not supported (This will not work `s3sync --sk KEY --ss SECRET s3://shared/megafile.zip fs:///opt/backups/s3/`)  
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"fmt"
-	"github.com/alexflint/go-arg"
-	"github.com/larrabee/s3sync/storage"
-	"github.com/mattn/go-isatty"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/alexflint/go-arg"
+	"github.com/larrabee/s3sync/storage"
+	"github.com/mattn/go-isatty"
 )
 
 var (
@@ -202,6 +203,10 @@ func parseConn(cStr string) (conn connect, err error) {
 		conn.Type = storage.TypeS3
 		conn.Bucket = u.Host
 		conn.Path = strings.TrimPrefix(u.Path, "/")
+  case "s3s":
+    conn.Type = storage.TypeS3Stream
+    conn.Bucket = u.Host
+    conn.Path = strings.TrimPrefix(u.Path, "/")
 	case "fs":
 		conn.Type = storage.TypeFS
 		conn.Path = strings.TrimPrefix(cStr, "fs://")

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -203,10 +203,10 @@ func parseConn(cStr string) (conn connect, err error) {
 		conn.Type = storage.TypeS3
 		conn.Bucket = u.Host
 		conn.Path = strings.TrimPrefix(u.Path, "/")
-  case "s3s":
-    conn.Type = storage.TypeS3Stream
-    conn.Bucket = u.Host
-    conn.Path = strings.TrimPrefix(u.Path, "/")
+	case "s3s":
+		conn.Type = storage.TypeS3Stream
+		conn.Bucket = u.Host
+		conn.Path = strings.TrimPrefix(u.Path, "/")
 	case "fs":
 		conn.Type = storage.TypeFS
 		conn.Path = strings.TrimPrefix(cStr, "fs://")

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/larrabee/s3sync/pipeline"
 	"github.com/larrabee/s3sync/pipeline/collection"
 	"github.com/larrabee/s3sync/storage"
 	"github.com/larrabee/s3sync/storage/fs"
 	"github.com/larrabee/s3sync/storage/s3"
-	"os"
+	"github.com/larrabee/s3sync/storage/s3stream"
 )
 
 func setupStorages(ctx context.Context, syncGroup *pipeline.Group, cli *argsParsed) error {
@@ -18,6 +20,10 @@ func setupStorages(ctx context.Context, syncGroup *pipeline.Group, cli *argsPars
 		sourceStorage = s3.NewS3Storage(cli.SourceNoSign, cli.SourceKey, cli.SourceSecret, cli.SourceToken, cli.SourceRegion, cli.SourceEndpoint,
 			cli.Source.Bucket, cli.Source.Path, cli.S3KeysPerReq, cli.S3Retry, cli.S3RetryInterval,
 		)
+  case storage.TypeS3Stream:
+    sourceStorage = s3stream.NewS3StreamStorage(cli.SourceNoSign, cli.SourceKey, cli.SourceSecret, cli.SourceToken, cli.SourceRegion, cli.SourceEndpoint,
+			cli.Source.Bucket, cli.Source.Path, cli.S3KeysPerReq, cli.S3Retry, cli.S3RetryInterval,
+		)
 	case storage.TypeFS:
 		sourceStorage = fs.NewFSStorage(cli.Source.Path, cli.FSFilePerm, cli.FSDirPerm, os.Getpagesize()*256*32, !cli.FSDisableXattr, cli.ErrorHandlingMask, cli.FSAtomicWrite)
 	}
@@ -25,6 +31,10 @@ func setupStorages(ctx context.Context, syncGroup *pipeline.Group, cli *argsPars
 	switch cli.Target.Type {
 	case storage.TypeS3:
 		targetStorage = s3.NewS3Storage(cli.TargetNoSign, cli.TargetKey, cli.TargetSecret, cli.TargetToken, cli.TargetRegion, cli.TargetEndpoint,
+			cli.Target.Bucket, cli.Target.Path, cli.S3KeysPerReq, cli.S3Retry, cli.S3RetryInterval,
+		)
+  case storage.TypeS3Stream:
+		targetStorage = s3stream.NewS3StreamStorage(cli.TargetNoSign, cli.TargetKey, cli.TargetSecret, cli.TargetToken, cli.TargetRegion, cli.TargetEndpoint,
 			cli.Target.Bucket, cli.Target.Path, cli.S3KeysPerReq, cli.S3Retry, cli.S3RetryInterval,
 		)
 	case storage.TypeFS:

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -20,8 +20,8 @@ func setupStorages(ctx context.Context, syncGroup *pipeline.Group, cli *argsPars
 		sourceStorage = s3.NewS3Storage(cli.SourceNoSign, cli.SourceKey, cli.SourceSecret, cli.SourceToken, cli.SourceRegion, cli.SourceEndpoint,
 			cli.Source.Bucket, cli.Source.Path, cli.S3KeysPerReq, cli.S3Retry, cli.S3RetryInterval,
 		)
-  case storage.TypeS3Stream:
-    sourceStorage = s3stream.NewS3StreamStorage(cli.SourceNoSign, cli.SourceKey, cli.SourceSecret, cli.SourceToken, cli.SourceRegion, cli.SourceEndpoint,
+	case storage.TypeS3Stream:
+		sourceStorage = s3stream.NewS3StreamStorage(cli.SourceNoSign, cli.SourceKey, cli.SourceSecret, cli.SourceToken, cli.SourceRegion, cli.SourceEndpoint,
 			cli.Source.Bucket, cli.Source.Path, cli.S3KeysPerReq, cli.S3Retry, cli.S3RetryInterval,
 		)
 	case storage.TypeFS:
@@ -33,7 +33,7 @@ func setupStorages(ctx context.Context, syncGroup *pipeline.Group, cli *argsPars
 		targetStorage = s3.NewS3Storage(cli.TargetNoSign, cli.TargetKey, cli.TargetSecret, cli.TargetToken, cli.TargetRegion, cli.TargetEndpoint,
 			cli.Target.Bucket, cli.Target.Path, cli.S3KeysPerReq, cli.S3Retry, cli.S3RetryInterval,
 		)
-  case storage.TypeS3Stream:
+	case storage.TypeS3Stream:
 		targetStorage = s3stream.NewS3StreamStorage(cli.TargetNoSign, cli.TargetKey, cli.TargetSecret, cli.TargetToken, cli.TargetRegion, cli.TargetEndpoint,
 			cli.Target.Bucket, cli.Target.Path, cli.S3KeysPerReq, cli.S3Retry, cli.S3RetryInterval,
 		)

--- a/pipeline/collection/misc.go
+++ b/pipeline/collection/misc.go
@@ -28,7 +28,7 @@ var Logger pipeline.StepFn = func(group *pipeline.Group, stepNum int, input <-ch
 		if ok {
 			cfg.WithFields(logrus.Fields{
 				"key":          *obj.Key,
-				"size":         len(*obj.Content),
+				"size":         *obj.ContentLength,
 				"Content-Type": *obj.ContentType,
 			}).Infof("Sync file")
 			output <- obj

--- a/storage/fs/fs.go
+++ b/storage/fs/fs.go
@@ -5,16 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/karrick/godirwalk"
-	"github.com/larrabee/ratelimit"
-	"github.com/larrabee/s3sync/storage"
-	"github.com/pkg/xattr"
 	"io"
 	"io/ioutil"
 	"mime"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/karrick/godirwalk"
+	"github.com/larrabee/ratelimit"
+	"github.com/larrabee/s3sync/storage"
+	"github.com/pkg/xattr"
 )
 
 const tempFileSuffixLen = 8
@@ -188,7 +189,10 @@ func (st *FSStorage) GetObjectContent(obj *storage.Object) error {
 		return err
 	}
 
+  dataSize := int64(len(data))
+
 	obj.Content = &data
+  obj.ContentLength = &dataSize
 
 	if err := st.GetObjectMeta(obj); err != nil {
 		return err

--- a/storage/fs/fs.go
+++ b/storage/fs/fs.go
@@ -150,7 +150,15 @@ func (st *FSStorage) PutObject(obj *storage.Object) error {
 	}
 	defer f.Close()
 
-	objReader := bytes.NewReader(*obj.Content)
+  // Implement a fallback for FS to handle io.Reader implementations natively
+  var objReader io.Reader
+  if obj.ContentStream != nil {
+    objReader = obj.ContentStream
+    defer obj.ContentStream.Close()
+  } else {
+    objReader = bytes.NewReader(*obj.Content)
+  }
+
 	if _, err := io.Copy(f, ratelimit.NewReader(objReader, st.rlBucket)); err != nil {
 		return err
 	}

--- a/storage/fs/fs.go
+++ b/storage/fs/fs.go
@@ -189,10 +189,10 @@ func (st *FSStorage) GetObjectContent(obj *storage.Object) error {
 		return err
 	}
 
-  dataSize := int64(len(data))
+	dataSize := int64(len(data))
 
 	obj.Content = &data
-  obj.ContentLength = &dataSize
+	obj.ContentLength = &dataSize
 
 	if err := st.GetObjectMeta(obj); err != nil {
 		return err

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -187,7 +187,7 @@ func (st *S3Storage) GetObjectContent(obj *storage.Object) error {
 	data := buf.Bytes()
 	obj.Content = &data
 	obj.ContentType = result.ContentType
-  obj.ContentLength = result.ContentLength
+	obj.ContentLength = result.ContentLength
 	obj.ContentDisposition = result.ContentDisposition
 	obj.ContentEncoding = result.ContentEncoding
 	obj.ContentLanguage = result.ContentLanguage

--- a/storage/s3stream/s3stream.go
+++ b/storage/s3stream/s3stream.go
@@ -30,7 +30,7 @@ type S3StreamStorage struct {
 	ctx           context.Context
 	listMarker    *string
 	rlBucket      ratelimit.Bucket
-  uploader      *s3manager.Uploader
+	uploader      *s3manager.Uploader
 }
 
 // NewS3Storage return new configured S3 storage.
@@ -65,7 +65,7 @@ func NewS3StreamStorage(awsNoSign bool, awsAccessKey, awsSecretKey, awsToken, aw
 		sess.Config.Region = aws.String("us-east-1")
 	}
 
-  uploader := s3manager.NewUploader(sess)
+uploader := s3manager.NewUploader(sess)
 
 	st := S3StreamStorage{
 		awsBucket:     &bucketName,
@@ -77,7 +77,7 @@ func NewS3StreamStorage(awsNoSign bool, awsAccessKey, awsSecretKey, awsToken, aw
 		retryInterval: retryDelay,
 		ctx:           context.TODO(),
 		rlBucket:      ratelimit.NewFakeBucket(),
-    uploader:      uploader,
+		uploader:      uploader,
 	}
 
 	return &st
@@ -135,12 +135,12 @@ func (st *S3StreamStorage) List(output chan<- *storage.Object) error {
 // PutObject saves object to S3.
 // PutObject ignore VersionId, it always save object as latest version.
 func (st *S3StreamStorage) PutObject(obj *storage.Object) error {
-  if (obj.ContentStream == nil) {
-    return errors.New("object has no contentStream");
-  }
+	if (obj.ContentStream == nil) {
+		return errors.New("object has no contentStream");
+	}
 
-  rlReader := ratelimit.NewReadCloser(obj.ContentStream, st.rlBucket);
-  defer rlReader.Close()
+	rlReader := ratelimit.NewReadCloser(obj.ContentStream, st.rlBucket);
+	defer rlReader.Close()
 	input := &s3manager.UploadInput{
 		Bucket:             st.awsBucket,
 		Key:                aws.String(st.prefix + *obj.Key),
@@ -155,9 +155,9 @@ func (st *S3StreamStorage) PutObject(obj *storage.Object) error {
 		StorageClass:       obj.StorageClass,
 	}
 
-  if _, err := st.uploader.UploadWithContext(st.ctx, input); err != nil {
-    return err
-  }
+	if _, err := st.uploader.UploadWithContext(st.ctx, input); err != nil {
+		return err
+	}
 
 
 	if obj.AccessControlPolicy != nil {
@@ -188,10 +188,10 @@ func (st *S3StreamStorage) GetObjectContent(obj *storage.Object) error {
 		return err
 	}
 
-  obj.Content = nil
+	obj.Content = nil
 	obj.ContentStream = result.Body
 	obj.ContentType = result.ContentType
-  obj.ContentLength = result.ContentLength
+	obj.ContentLength = result.ContentLength
 	obj.ContentDisposition = result.ContentDisposition
 	obj.ContentEncoding = result.ContentEncoding
 	obj.ContentLanguage = result.ContentLanguage

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3,9 +3,11 @@ package storage
 
 import (
 	"context"
+	"io"
+	"time"
+
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/sirupsen/logrus"
-	"time"
 )
 
 // Log implement Logrus logger for debug logging.
@@ -19,6 +21,7 @@ const (
 	TypeS3 Type = iota + 1
 	TypeS3Versioned
 	TypeFS
+  TypeS3Stream
 )
 
 // Object contain content and metadata of S3 object.
@@ -27,6 +30,8 @@ type Object struct {
 	ETag                *string                 `json:"e_tag"`
 	Mtime               *time.Time              `json:"mtime"`
 	Content             *[]byte                 `json:"-"`
+  ContentStream       io.ReadCloser           `json:"-"`
+  ContentLength       *int64                 `json:"-"`
 	ContentType         *string                 `json:"content_type"`
 	ContentDisposition  *string                 `json:"content_disposition"`
 	ContentEncoding     *string                 `json:"content_encoding"`

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -21,7 +21,7 @@ const (
 	TypeS3 Type = iota + 1
 	TypeS3Versioned
 	TypeFS
-  TypeS3Stream
+	TypeS3Stream
 )
 
 // Object contain content and metadata of S3 object.
@@ -30,8 +30,8 @@ type Object struct {
 	ETag                *string                 `json:"e_tag"`
 	Mtime               *time.Time              `json:"mtime"`
 	Content             *[]byte                 `json:"-"`
-  ContentStream       io.ReadCloser           `json:"-"`
-  ContentLength       *int64                 `json:"-"`
+	ContentStream       io.ReadCloser           `json:"-"`
+	ContentLength       *int64                 `json:"-"`
 	ContentType         *string                 `json:"content_type"`
 	ContentDisposition  *string                 `json:"content_disposition"`
 	ContentEncoding     *string                 `json:"content_encoding"`


### PR DESCRIPTION
This PR implements a streaming S3 sync.
It is implemented just like I outlined it in the issue, by utilizing the new s3manager.Uploader.

Users can opt-in to use the streaming sync by using `s3s://` as a protocol.