### PR TITLE
Add flag to set Cache-Control header on uploaded files

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -60,6 +60,7 @@ type args struct {
 	S3Retry         uint   `arg:"--s3-retry" help:"Max numbers of retries to sync file"`
 	S3RetryInterval uint   `arg:"--s3-retry-sleep" help:"Sleep interval (sec) between sync retries on error"`
 	S3Acl           string `arg:"--s3-acl" help:"S3 ACL for uploaded files. Possible values: private, public-read, public-read-write, aws-exec-read, authenticated-read, bucket-owner-read, bucket-owner-full-control"`
+	S3CacheControl  string `arg:"--s3-cache-control" help:"Cache-Control header for uploaded files."`
 	S3StorageClass  string `arg:"--s3-storage-class" help:"S3 Storage Class for uploaded files."`
 	S3KeysPerReq    int64  `arg:"--s3-keys-per-req" help:"Max numbers of keys retrieved via List request"`
 	// FS config

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -193,6 +193,14 @@ func setupPipeline(syncGroup *pipeline.Group, cli *argsParsed) {
 		})
 	}
 
+	if cli.S3CacheControl != "" {
+		syncGroup.AddPipeStep(pipeline.Step{
+			Name:   "CacheControlUpdater",
+			Fn:     collection.CacheControlUpdater,
+			Config: cli.S3CacheControl,
+		})
+	}
+
 	syncGroup.AddPipeStep(pipeline.Step{
 		Name:       "UploadObj",
 		Fn:         collection.UploadObjectData,

--- a/pipeline/collection/misc.go
+++ b/pipeline/collection/misc.go
@@ -69,6 +69,21 @@ var StorageClassUpdater pipeline.StepFn = func(group *pipeline.Group, stepNum in
 	}
 }
 
+// CacheControlUpdater updates the cache control.
+var CacheControlUpdater pipeline.StepFn = func(group *pipeline.Group, stepNum int, input <-chan *storage.Object, output chan<- *storage.Object, errChan chan<- error) {
+	info := group.GetStepInfo(stepNum)
+	cfg, ok := info.Config.(string)
+	if !ok {
+		errChan <- &pipeline.StepConfigurationError{StepName: info.Name, StepNum: stepNum}
+	}
+	for obj := range input {
+		if ok {
+			obj.CacheControl = &cfg
+			output <- obj
+		}
+	}
+}
+
 // PipelineRateLimit read objects from input and slow down pipeline processing speed to given rate (obj/sec).
 //
 // This filter read configuration from Step.Config and assert it type to uint type.


### PR DESCRIPTION
Adds a `--s3-cache-control` parameter which allows a user to set the Cache-Control header on uploaded files.