### PR TITLE
dockerfile: switch to chainguard image to reduce CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Build in Docker container
-FROM golang:1.19.2 as builder
+FROM cgr.dev/chainguard/go:1.19.2@sha256:3f7206a2cfbf680b63f71188cd76c7597d35720a0a9a6c95fc5c9556ba74e332 as builder
 
 ENV CGO_ENABLED 0
 WORKDIR /src/s3sync
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . ./
-RUN go mod vendor && \
-    go build -o s3sync ./cli
+RUN go build -o s3sync ./cli
 
 # Create s3sync image
-FROM debian:buster-slim
-RUN apt update && apt install -y ca-certificates
+FROM cgr.dev/chainguard/glibc-dynamic:latest
 COPY --from=builder /src/s3sync/s3sync /s3sync
 ENTRYPOINT ["/s3sync"]


### PR DESCRIPTION
switch from debian:buster-slim to Chainguard's  glibc-dynamic image as base to reduce CVEs.

before:

```
larrabee/s3sync (debian 10.5)

Total: 216 (UNKNOWN: 5, LOW: 93, MEDIUM: 36, HIGH: 63, CRITICAL: 19)
```

after:

```
2023-07-03T02:54:46.447Z        INFO    Vulnerability scanning is enabled
2023-07-03T02:54:46.447Z        INFO    Secret scanning is enabled
2023-07-03T02:54:46.447Z        INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-07-03T02:54:46.447Z        INFO    Please see also https://aquasecurity.github.io/trivy/v0.39/docs/secret/scanning/#recommendation for faster secret detection
2023-07-03T02:54:46.451Z        INFO    Detected OS: wolfi
2023-07-03T02:54:46.451Z        INFO    Detecting Wolfi vulnerabilities...
2023-07-03T02:54:46.451Z        INFO    Number of language-specific files: 1
2023-07-03T02:54:46.451Z        INFO    Detecting gobinary vulnerabilities...

s3sync:test (wolfi 20230201)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


s3sync (gobinary)

Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.294         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
```