### PR TITLE
use alpine linux for a smaller docker (from 118MB to 28MB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build in Docker container
-FROM golang:1.19.2 as builder
+FROM golang:1.20.5-alpine as builder
 
 ENV CGO_ENABLED 0
 WORKDIR /src/s3sync
@@ -8,7 +8,6 @@ RUN go mod vendor && \
     go build -o s3sync ./cli
 
 # Create s3sync image
-FROM debian:buster-slim
-RUN apt update && apt install -y ca-certificates
-COPY --from=builder /src/s3sync/s3sync /s3sync
+FROM alpine
+COPY --link --from=builder /src/s3sync/s3sync /s3sync
 ENTRYPOINT ["/s3sync"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ RUN go mod vendor && \
 
 # Create s3sync image
 FROM alpine
+RUN apk --no-cache add ca-certificates
 COPY --link --from=builder /src/s3sync/s3sync /s3sync
 ENTRYPOINT ["/s3sync"]


### PR DESCRIPTION

Use COPY --link which allows upgrades to later alpine linuxes and sharing the same layer
--link copies the file as a binary, so when you upgrade the base image without changing the code the layer is reused between the images. 