### PR TITLE
Update filter.go to missing when using sliding windows data.

### DIFF
--- a/pipeline/collection/filter.go
+++ b/pipeline/collection/filter.go
@@ -131,7 +131,7 @@ var FilterObjectsByMtimeAfter pipeline.StepFn = func(group *pipeline.Group, step
 	}
 	for obj := range input {
 		if ok {
-			if obj.Mtime.Unix() > cfg {
+			if obj.Mtime.Unix() >= cfg {
 				output <- obj
 			}
 		}


### PR DESCRIPTION
When using a sliding window some files will be missed if the sync time happens to be exactly the same. I.e. if we do a sync from 0 to 10 and then 10 to 20 we will miss any changes at 10 and 0.